### PR TITLE
Added PacketElementArray, a new version of the PacketArray element

### DIFF
--- a/trunk/dev/VCProjects/ZoneServer.vcxproj.filters
+++ b/trunk/dev/VCProjects/ZoneServer.vcxproj.filters
@@ -1148,7 +1148,6 @@
     <ClInclude Include="..\..\source\ZoneServer\Packets\OP_EnterMoveObjectModeMsg_Packet.h">
       <Filter>source\Packets\Server-&gt;Client</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\source\common\Packets\PacketElements\PacketCharString.h" />
     <ClInclude Include="..\..\source\ZoneServer\Packets\OP_UpdateRaidMsg_Packet.h">
       <Filter>source\Packets\Server-&gt;Client</Filter>
     </ClInclude>
@@ -1202,6 +1201,9 @@
     </ClInclude>
     <ClInclude Include="..\..\source\ZoneServer\Packets\OP_PopulateSkillMapsMsg.h">
       <Filter>source\Packets\Server-&gt;Client</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\common\Packets\PacketElements\PacketCharString.h">
+      <Filter>common\Packets\PacketElements</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/trunk/source/common/Mutex.cpp
+++ b/trunk/source/common/Mutex.cpp
@@ -18,9 +18,10 @@ const chrono::seconds MUTEX_TIMEOUT(MUTEX_TIMEOUT_SECONDS);
 * @brief Constructor.
 *
 */
-Mutex::Mutex() : num_readlocks(0) {
+Mutex::Mutex() {
 #if defined(EQ2_DEBUG)
 	name[0] = 0;
+	num_readlocks = 0
 #endif
 }
 
@@ -29,8 +30,9 @@ Mutex::Mutex() : num_readlocks(0) {
 *
 * @param name The name of the mutex.
 */
-Mutex::Mutex(const char* name) : num_readlocks(0) {
+Mutex::Mutex(const char* name) {
 #if defined(EQ2_DEBUG)
+	num_readlocks = 0;
 	strncpy(this->name, name, sizeof(this->name) - 1);
 #endif
 }

--- a/trunk/source/common/Packets/EQ2Packet.cpp
+++ b/trunk/source/common/Packets/EQ2Packet.cpp
@@ -163,7 +163,7 @@ void EQ2Packet::PreWrite() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PreWrite();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PreWrite();
 		}
 	}
@@ -174,7 +174,7 @@ void EQ2Packet::PostWrite() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PostWrite();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PostWrite();
 		}
 	}
@@ -185,7 +185,7 @@ void EQ2Packet::PostRead() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PostRead();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PostRead();
 		}
 	}
@@ -196,7 +196,7 @@ void EQ2Packet::PreRead() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PreRead();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PreRead();
 		}
 	}

--- a/trunk/source/common/Packets/PacketElements/PacketElements.h
+++ b/trunk/source/common/Packets/PacketElements/PacketElements.h
@@ -51,6 +51,8 @@
 #define RegisterInt64(e) PushElementForRegistration(new PacketInt64(e), #e, PacketInt64)
 #define RegisterSubstruct(e) PushElementForRegistration(new PacketSubstructParent<std::remove_reference_t<decltype(e)>>(e), #e, PacketSubstructParent<std::remove_reference_t<decltype(e)>>)
 #define RegisterArray(e, t) (static_cast<PacketArray<t>*>(PushElementForRegistration(new PacketArray<t>(e), #e, PacketArrayBase))->SetVersion(GetVersion()), static_cast<PacketArrayBase*>(elements.back()))
+#define ELE_REGISTER_COMMA ,
+#define RegisterElementArray(e, t, p) PushElementForRegistration(new PacketElementArray<t ELE_REGISTER_COMMA p>(e), #e, PacketElementArrayBase)
 #define RegisterEQ2Color(e) PushElementForRegistration(new PacketEQ2Color(e), #e, PacketEQ2Color)
 #define RegisterEQ2ColorFloat(e) PushElementForRegistration(new PacketEQ2ColorFloat(e), #e, PacketEQ2ColorFloat)
 #define RegisterEQ2EquipmentItem(e, bShortType) PushElementForRegistration(new PacketEQ2EquipmentItem(e, (bShortType)), #e, PacketEQ2EquipmentItem)

--- a/trunk/source/common/Packets/PacketElements/PacketSubstruct.cpp
+++ b/trunk/source/common/Packets/PacketElements/PacketSubstruct.cpp
@@ -9,7 +9,7 @@ void PacketSubstruct::PreWrite() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PreWrite();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PreWrite();
 		}
 	}
@@ -20,7 +20,7 @@ void PacketSubstruct::PostWrite() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PostWrite();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PostWrite();
 		}
 	}
@@ -31,7 +31,7 @@ void PacketSubstruct::PostRead() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PostRead();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PostRead();
 		}
 	}
@@ -42,7 +42,7 @@ void PacketSubstruct::PreRead() {
 		if (auto substr = dynamic_cast<PacketSubstructParentBase*>(e)) {
 			substr->PreRead();
 		}
-		if (auto arr = dynamic_cast<PacketArrayBase*>(e)) {
+		if (auto arr = dynamic_cast<PacketSubstructArray*>(e)) {
 			arr->PreRead();
 		}
 	}

--- a/trunk/source/common/Packets/PacketElements/PacketSubstruct.h
+++ b/trunk/source/common/Packets/PacketElements/PacketSubstruct.h
@@ -93,7 +93,7 @@ public:
 	virtual void PostRead();
 
 protected:
-	PacketSubstruct(uint32_t p_version, bool p_inline = false): elementsInitialized(false), version(p_version), bInline(p_inline) {
+	PacketSubstruct(uint32_t p_version, bool p_inline = false) : elementsInitialized(false), version(p_version), bInline(p_inline) {
 	}
 
 	//Copy constructor

--- a/trunk/source/common/Packets/XmlStructDumper.cpp
+++ b/trunk/source/common/Packets/XmlStructDumper.cpp
@@ -134,7 +134,7 @@ void XmlStructDumper::ElementToXml(PacketElement* e, xml_document<>& doc, xml_no
 			ElementToXml(itr, doc, *dataNode);
 		}
 	}
-	else if (auto pa = dynamic_cast<PacketArrayBase*>(e)) {
+	else if (auto pa = dynamic_cast<PacketSubstructArray*>(e)) {
 		dataNode->append_attribute(doc.allocate_attribute("ElementName", doc.allocate_string(e->name)));
 		dataNode->append_attribute(doc.allocate_attribute("Type", "Array"));
 		dataNode->append_attribute(doc.allocate_attribute("ArraySizeVariable", pa->arraySizeName));
@@ -143,6 +143,15 @@ void XmlStructDumper::ElementToXml(PacketElement* e, xml_document<>& doc, xml_no
 		std::string defaultArrayDataName = std::string(e->name) + "_data";
 		arrayType->SetName(defaultArrayDataName.c_str());
 		ElementToXml(arrayType.get(), doc, *dataNode);
+	}
+	else if (auto pa = dynamic_cast<PacketElementArrayBase*>(e)) {
+		dataNode->append_attribute(doc.allocate_attribute("ElementName", doc.allocate_string(e->name)));
+		dataNode->append_attribute(doc.allocate_attribute("Type", "Array"));
+		dataNode->append_attribute(doc.allocate_attribute("ArraySizeVariable", pa->arraySizeName));
+		auto pe = pa->GetArrayTypeElement();
+		std::string defaultArrayDataName = std::string(e->name) + "_data";
+		pe->name = defaultArrayDataName.c_str();
+		ElementToXml(pe.get(), doc, *dataNode);
 	}
 	else if (auto ps = dynamic_cast<PacketSubstruct*>(e)) {
 		//This is is encoded data add an extra tag


### PR DESCRIPTION
Example: std::vector<float> with along with PacketFloat for its template without needing a substruct